### PR TITLE
Pre-commit before Mobile css sheet works begin

### DIFF
--- a/app/four-days/four-days.template.html
+++ b/app/four-days/four-days.template.html
@@ -1,27 +1,26 @@
-
 <div class="row" data-active-view-item="fourdays">
-	<div class="col">
-		<h2> {{ $ctrl.getTitle() }}</h2>
-	</div>
+    <div class="col">
+        <h4> {{ $ctrl.getTitle() }}</h4>
+    </div>
 </div>
 
 <table class="table table-striped table-responsive-md table-dark table-bordered">
-	<thead>
-		<tr>
-			<th>Day</th>
-			<th>Forecast</th>
-			<th>Temperature</th>
-			<th>Humidity</th>
-			<th>Wind Information</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr ng-repeat="day in $ctrl.getDays()">
-			<td>{{ $ctrl.getDays()[$index] }}</td>
-			<td>{{ $ctrl.getForecastDescriptions()[$index] }}</td>
-			<td>{{ $ctrl.getTemperatures()[$index] }}</td>
-			<td>{{ $ctrl.getRelativeHumidities()[$index] }}</td>
-			<td>{{ $ctrl.getWindInformation()[$index] }}</td>
-		</tr>
-	</tbody>
+    <thead>
+    <tr>
+        <th>Day</th>
+        <th>Forecast</th>
+        <th>Temperature</th>
+        <th>Humidity</th>
+        <th>Wind Information</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="day in $ctrl.getDays()">
+        <td>{{ $ctrl.getDays()[$index] }}</td>
+        <td>{{ $ctrl.getForecastDescriptions()[$index] }}</td>
+        <td>{{ $ctrl.getTemperatures()[$index] }}</td>
+        <td>{{ $ctrl.getRelativeHumidities()[$index] }}</td>
+        <td>{{ $ctrl.getWindInformation()[$index] }}</td>
+    </tr>
+    </tbody>
 </table>

--- a/app/heavy-rain/heavy-rain.template.html
+++ b/app/heavy-rain/heavy-rain.template.html
@@ -1,9 +1,11 @@
 <div class="row" data-active-view-item="heavyrain">
-	<div class="col">
-		<h2> {{ $ctrl.getTitle() }}</h2>
-	</div>
+    <div class="col">
+        <h4> {{ $ctrl.getTitle() }}</h4>
+    </div>
 </div>
 
-<p> {{ $ctrl.getWarning() }}</p>
+<p class="whiteParas"> {{ $ctrl.getWarning() }}</p>
 
-<img class="img-fluid" ng-src="{{'data:image/gif;base64,'+$ctrl.getRainAreaImage()}}" >
+<div class="text-center forecastfour">
+    <img class="img-fluid " ng-src="{{'data:image/gif;base64,'+$ctrl.getRainAreaImage()}}">
+</div>

--- a/app/pm25/pm25.template.html
+++ b/app/pm25/pm25.template.html
@@ -1,30 +1,30 @@
 <div class="row" data-active-view-item="pm25">
-	<div class="col">
-		<h2>PM2.5 Readings</h2>
-	</div>
+    <div class="col">
+        <h4>PM2.5 Readings</h4>
+    </div>
 </div>
 
 <table class="table table-striped table-responsive-md table-dark table-bordered">
-	<thead>
-		<tr>
-			<th>Region</th>
-			<th>Latitude</th>
-			<th>Longitude</th>
-			<th>Pm 2.5</th>
-			<th>Band</th>
-			<th>Band Descriptor</th>
-			<th>Timestamp</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr ng-repeat="region in $ctrl.getRegions()">
-			<td>{{ $ctrl.abbrs[region.id] }}</td>
-			<td>{{ region.latitude }}</td>
-			<td>{{ region.longitude }}</td>
-			<td>{{ region.record.reading._value }}</td>
-			<td>{{ $ctrl.getBand(region.record.reading._value) }}</td>
-			<td>{{ $ctrl.getDescriptor(region.record.reading._value) }}</td>
-			<td>{{ $ctrl.getDate(region.record._timestamp) }}</td>	
-		</tr>
-	</tbody>
+    <thead>
+    <tr>
+        <th>Region</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+        <th>Pm 2.5</th>
+        <th>Band</th>
+        <th>Band Descriptor</th>
+        <th>Timestamp</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="region in $ctrl.getRegions()">
+        <td>{{ $ctrl.abbrs[region.id] }}</td>
+        <td>{{ region.latitude }}</td>
+        <td>{{ region.longitude }}</td>
+        <td>{{ region.record.reading._value }}</td>
+        <td>{{ $ctrl.getBand(region.record.reading._value) }}</td>
+        <td>{{ $ctrl.getDescriptor(region.record.reading._value) }}</td>
+        <td>{{ $ctrl.getDate(region.record._timestamp) }}</td>
+    </tr>
+    </tbody>
 </table>

--- a/app/psi/psi.template.html
+++ b/app/psi/psi.template.html
@@ -1,30 +1,30 @@
 <div class="row" data-active-view-item="psi">
-	<div class="col">
-		<h2>PSI Readings</h2>
-	</div>
+    <div class="col">
+        <!--<h4>PSI Readings</h4>-->
+    </div>
 </div>
 
-<table class="table table-striped table-responsive table-dark table-bordered">
-	<thead>
-		<tr>
-			<th>Region</th>
-			<th>Latitude</th>
-			<th>Longitude</th>
-			<th>PSI Descriptor</th>
-			<th ng-repeat="p in $ctrl.pollutants">{{p}}</th>
-			<th>Timestamp</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr ng-repeat="region in $ctrl.getRegions()">
-			<td>{{ $ctrl.abbrs[region.id] }}</td>
-			<td>{{ region.latitude }}</td>
-			<td>{{ region.longitude }}</td>
-			<td>{{ $ctrl.getPSIDescriptor(region.record.reading[0]._value) }}</td>
-			<td ng-repeat="p in $ctrl.pollutants">
-				{{ $ctrl.getPollutantReading(region.record.reading, p)}}
-			</td>
-			<td>{{ $ctrl.getDate(region.record._timestamp) }}</td>
-		</tr>
-	</tbody>
+<table id="psiTable" class="table table-striped table-responsive table-dark table-bordered">
+    <thead>
+    <tr>
+        <th>Region</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+        <th>PSI Descriptor</th>
+        <th ng-repeat="p in $ctrl.pollutants">{{p}}</th>
+        <th>Timestamp</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="region in $ctrl.getRegions()">
+        <td>{{ $ctrl.abbrs[region.id] }}</td>
+        <td>{{ region.latitude }}</td>
+        <td>{{ region.longitude }}</td>
+        <td>{{ $ctrl.getPSIDescriptor(region.record.reading[0]._value) }}</td>
+        <td ng-repeat="p in $ctrl.pollutants">
+            {{ $ctrl.getPollutantReading(region.record.reading, p)}}
+        </td>
+        <td>{{ $ctrl.getDate(region.record._timestamp) }}</td>
+    </tr>
+    </tbody>
 </table>

--- a/app/shared/css/style.css
+++ b/app/shared/css/style.css
@@ -22,7 +22,7 @@ html, body {
     background-color: rgba(0, 0, 0, 0.0) !important;
 }
 
-h2, h4 {
+h2, h4, h5, .whiteParas {
     color: #eee;
 }
 
@@ -220,7 +220,7 @@ h2, h4 {
     z-index: 100;
 }
 
-/*General styling plus image blurring technique on nowcast*/
+/*General styling across all templates*/
 .form-control {
     margin-bottom: 10px;
 }

--- a/app/today/today.template.html
+++ b/app/today/today.template.html
@@ -1,38 +1,37 @@
-
 <div class="row" data-active-view-item="today">
-	<div class="col">
-		<h2> {{ $ctrl.getTitle() }} ({{ $ctrl.getValidTime() }})</h2>
-	</div>
+    <div class="col">
+        <h4> {{ $ctrl.getTitle() }} ({{ $ctrl.getValidTime() }})</h4>
+    </div>
 </div>
 
 <div style="padding-top: 10px; padding-bottom: 10px" class="row">
-	<div class="col">
-		<h4> {{ $ctrl.getMainForecastDescription() }} </h4>
-	</div>
-	<div class="col">
-		<h4>{{ $ctrl.getTempLow() }}°C - {{ $ctrl.getTempHigh() }}°C</h4>
-		<h4>Humidity: {{ $ctrl.getHumidityLow() }}% - {{ $ctrl.getHumidityHigh() }}%</h4>
-		<h4>Wind: {{ $ctrl.getWindDirection() }} ({{ $ctrl.getWindSpeed() }})</h4>
-	</div>
+    <div class="col">
+        <h5> {{ $ctrl.getMainForecastDescription() }} </h5>
+    </div>
+    <div class="col">
+        <h5>Temp: {{ $ctrl.getTempLow() }}°C - {{ $ctrl.getTempHigh() }}°C</h5>
+        <h5>Humidity: {{ $ctrl.getHumidityLow() }}% - {{ $ctrl.getHumidityHigh() }}%</h5>
+        <h5>Wind: {{ $ctrl.getWindDirection() }} ({{ $ctrl.getWindSpeed() }})</h5>
+    </div>
 </div>
 
 <table class="table table-striped table-responsive-md table-dark table-bordered">
-	<thead>
-		<tr>
-			<th>Time Period</th>
-			<th>North</th>
-			<th>South</th>
-			<th>East</th>
-			<th>West</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr ng-repeat="item in $ctrl.getForecastTimePeriodArea()">
-			<td>{{ item.timePeriod }}</td>
-			<td>{{ item.wxnorth }}</td>
-			<td>{{ item.wxsouth }}</td>
-			<td>{{ item.wxeast }}</td>
-			<td>{{ item.wxwest }}</td>
-		</tr>
-	</tbody>
+    <thead>
+    <tr>
+        <th>Time Period</th>
+        <th>North</th>
+        <th>South</th>
+        <th>East</th>
+        <th>West</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="item in $ctrl.getForecastTimePeriodArea()">
+        <td>{{ item.timePeriod }}</td>
+        <td>{{ item.wxnorth }}</td>
+        <td>{{ item.wxsouth }}</td>
+        <td>{{ item.wxeast }}</td>
+        <td>{{ item.wxwest }}</td>
+    </tr>
+    </tbody>
 </table>


### PR DESCRIPTION
(1) All files automatically formatted and indented with 4-space tab indent (default IDE behaviour)

(2) Reduced size of some headers from h2 to h4 so that they won't be so much bigger than the brand on top left corner.

(3)Removed heading on PSI table page as that was introducing unnecessary vertical scrollbars.

(4) added translucent overlay on heavy rain warning page for clarity and contrast between image and background image.

**I have finally gotten round to doing the mobile media queries **